### PR TITLE
use HTTP::FormData in stdlib

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,12 +7,6 @@ authors:
 
 license: MIT
 
-dependencies:
-  # Will go away pending the merge of
-  # https://github.com/crystal-lang/crystal/pull/3844
-  multipart:
-    github: RX14/multipart.cr
-
 development_dependencies:
   timecop:
     github: waterlink/timecop.cr

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: awscr-signer
-version: 0.2.8
-crystal: 0.20.5
+version: 0.2.9
+crystal: 0.21.0
 
 authors:
   - Taylor Finnell <tmfinnell@gmail.com>

--- a/src/awscr-signer/presigned/form.cr
+++ b/src/awscr-signer/presigned/form.cr
@@ -1,4 +1,4 @@
-require "multipart"
+require "http"
 require "http/client"
 require "secure_random"
 
@@ -62,7 +62,7 @@ module Awscr
 
         private def body(io : IO)
           body_io = IO::Memory.new
-          HTTP::FormData.generate(body_io, @boundary) do |form|
+          HTTP::FormData.build(body_io, @boundary) do |form|
             @post.fields.each do |field|
               form.field(field.key, field.value)
             end

--- a/src/awscr-signer/version.cr
+++ b/src/awscr-signer/version.cr
@@ -1,7 +1,7 @@
 module Awscr
   MAJOR = "0"
   MINOR = "2"
-  PATCH = "8"
+  PATCH = "9"
 
   [MAJOR, MINOR, PATCH].join(".")
 end


### PR DESCRIPTION
- Remove `multipart` shard
- Use `HTTP::FormData` from stdlib