### PR TITLE
Crystal 0.30.0 fixes (escape -> encode)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,4 +9,4 @@ license: MIT
 
 development_dependencies:
   timecop:
-    github: waterlink/timecop.cr
+    github: crystal-community/timecop.cr

--- a/spec/awscr-signer/signers/v4_amazon_spec.cr
+++ b/spec/awscr-signer/signers/v4_amazon_spec.cr
@@ -12,234 +12,272 @@ module Awscr
 
       describe V4 do
         describe "signing an HTTP::Request" do
-          Spec.before_each do
-            Timecop.freeze(Time.unix(1440938160))
-          end
-
-          Spec.after_each do
-            Timecop.reset
-          end
+          time = Time.unix(1440938160)
 
           it "get-header-key-duplicate" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
 
-            request.headers.add("My-Header1", "value2")
-            request.headers.add("My-Header1", "value2")
-            request.headers.add("My-Header1", "value1")
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("My-Header1", "value2")
+              request.headers.add("My-Header1", "value2")
+              request.headers.add("My-Header1", "value1")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=c9d5ea9f3f72853aea855b47ea873832890dbdd183b4468f858259531a5138ea")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=c9d5ea9f3f72853aea855b47ea873832890dbdd183b4468f858259531a5138ea")
+            end
           end
 
           pending "get-header-value-multiline" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
 
-            request.headers.add("My-Header1", "value1\n   \n  value2  \nvalue3")
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("My-Header1", "value1\n   \n  value2  \nvalue3")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=ba17b383a53190154eb5fa66a1b836cc297cc0a3d70a5d00705980573d8ff790")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=ba17b383a53190154eb5fa66a1b836cc297cc0a3d70a5d00705980573d8ff790")
+            end
           end
 
           it "get-header-value-order" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
 
-            request.headers.add("My-Header1", "value4")
-            request.headers.add("My-Header1", "value1")
-            request.headers.add("My-Header1", "value3")
-            request.headers.add("My-Header1", "value2")
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("My-Header1", "value4")
+              request.headers.add("My-Header1", "value1")
+              request.headers.add("My-Header1", "value3")
+              request.headers.add("My-Header1", "value2")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=08c7e5a9acfcfeb3ab6b2185e75ce8b1deb5e634ec47601a50643f830c755c01")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=08c7e5a9acfcfeb3ab6b2185e75ce8b1deb5e634ec47601a50643f830c755c01")
+            end
           end
 
           it "get-header-value-trim" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
 
-            request.headers.add("My-Header1", "value1")
-            request.headers.add("My-Header2", "\"a   b   c\"")
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("My-Header1", "value1")
+              request.headers.add("My-Header2", "\"a   b   c\"")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;my-header2;x-amz-date, Signature=acc3ed3afb60bb290fc8d2dd0098b9911fcaa05412b367055dee359757a9c736")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;my-header2;x-amz-date, Signature=acc3ed3afb60bb290fc8d2dd0098b9911fcaa05412b367055dee359757a9c736")
+            end
           end
 
           it "get-unreserved" do
-            request = HTTP::Request.new("GET", "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=07ef7494c76fa4850883e2b006601f940f8a34d404d0cfa977f52a65bbf5f24f")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=07ef7494c76fa4850883e2b006601f940f8a34d404d0cfa977f52a65bbf5f24f")
+            end
           end
 
           it "get-utf8" do
-            request = HTTP::Request.new("GET", "/ሴ", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/ሴ", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85")
+            end
           end
 
           it "get-vanilla-empty-query-key" do
-            request = HTTP::Request.new("GET", "/?Param1=value1", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/?Param1=value1", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=a67d582fa61cc504c4bae71f336f98b97f1ea3c7a6bfe1b6e45aec72011b9aeb")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=a67d582fa61cc504c4bae71f336f98b97f1ea3c7a6bfe1b6e45aec72011b9aeb")
+            end
           end
 
           it "get-vanilla-query-order-key-case" do
-            request = HTTP::Request.new("GET", "/?Param1=value1&Param2=value2", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/?Param1=value1&Param2=value2", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500")
+            end
           end
 
           it "get-vanilla-query-unreserved" do
-            request = HTTP::Request.new("GET", "/?-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/?-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9c3e54bfcdf0b19771a7f523ee5669cdf59bc7cc0884027167c21bb143a40197")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9c3e54bfcdf0b19771a7f523ee5669cdf59bc7cc0884027167c21bb143a40197")
+            end
           end
 
           it "get-vanilla-query" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+            end
           end
 
           it "get-vanilla-utf8" do
-            request = HTTP::Request.new("GET", "/?ሴ=bar", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/?ሴ=bar", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=2cdec8eed098649ff3a119c94853b13c643bcf08f8b0a1d91e12c9027818dd04")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=2cdec8eed098649ff3a119c94853b13c643bcf08f8b0a1d91e12c9027818dd04")
+            end
           end
 
           it "get-vanilla" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+            end
           end
 
           describe "normalized path" do
             it "get-relative" do
-              request = HTTP::Request.new("GET", "/example/..", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "/example/..", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+              end
             end
 
             it "get-relative-relative" do
-              request = HTTP::Request.new("GET", "/example1/example2/../..", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "/example1/example2/../..", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+              end
             end
 
             it "get-slash-dot-slash" do
-              request = HTTP::Request.new("GET", "/./", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "/./", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+              end
             end
 
             it "get-slash-pointless-dot" do
-              request = HTTP::Request.new("GET", "/./example", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "/./example", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=ef75d96142cf21edca26f06005da7988e4f8dc83a165a80865db7089db637ec5")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=ef75d96142cf21edca26f06005da7988e4f8dc83a165a80865db7089db637ec5")
+              end
             end
 
             it "get-slash" do
-              request = HTTP::Request.new("GET", "//", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "//", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31")
+              end
             end
 
             pending "get-slashes" do
-              request = HTTP::Request.new("GET", "//example//", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "//example//", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9a624bd73a37c9a373b5312afbebe7a714a789de108f0bdfe846570885f57e84")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=9a624bd73a37c9a373b5312afbebe7a714a789de108f0bdfe846570885f57e84")
+              end
             end
 
             it "get-space" do
-              request = HTTP::Request.new("GET", "/example space/", HTTP::Headers.new)
+              with_time_freeze(time) do
+                request = HTTP::Request.new("GET", "/example space/", HTTP::Headers.new)
 
-              request.headers.add("Host", "example.amazonaws.com")
-              request.headers.add("X-Amz-Date", "20150830T123600Z")
-              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+                request.headers.add("Host", "example.amazonaws.com")
+                request.headers.add("X-Amz-Date", "20150830T123600Z")
+                request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=652487583200325589f1fba4c7e578f72c47cb61beeca81406b39ddec1366741")
+                assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=652487583200325589f1fba4c7e578f72c47cb61beeca81406b39ddec1366741")
+              end
             end
           end
 
           it "post-header-key-case" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b")
+            end
           end
 
           it "post-header-key-sort" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.add("My-Header1", "value1")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("My-Header1", "value1")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=c5410059b04c1ee005303aed430f6e6645f61f4dc9e1461ec8f8916fdf18852c")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=c5410059b04c1ee005303aed430f6e6645f61f4dc9e1461ec8f8916fdf18852c")
+            end
           end
 
           it "post-header-value-case" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.add("My-Header1", "VALUE1")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("My-Header1", "VALUE1")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=cdbc9802e29d2942e5e10b5bccfdd67c5f22c7c4e8ae67b53629efa58b974b7d")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;my-header1;x-amz-date, Signature=cdbc9802e29d2942e5e10b5bccfdd67c5f22c7c4e8ae67b53629efa58b974b7d")
+            end
           end
 
           describe "with sts token" do
@@ -251,76 +289,88 @@ module Awscr
           end
 
           it "post-vanilla-empty-query-value" do
-            request = HTTP::Request.new("POST", "/?Param1=value1", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/?Param1=value1", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=28038455d6de14eafc1f9222cf5aa6f1a96197d7deb8263271d420d138af7f11")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=28038455d6de14eafc1f9222cf5aa6f1a96197d7deb8263271d420d138af7f11")
+            end
           end
 
           it "post-vanilla-query-nonunreserved" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            request.query_params.add("@#$%^&+", "/,?><`\";:\\|][{}")
+              request.query_params.add("@#$%^&+", "/,?><`\";:\\|][{}")
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=88d3e39e4fa54b971f51c0a09140368e1a51aafb76c4652d9998f93cf3038074")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=88d3e39e4fa54b971f51c0a09140368e1a51aafb76c4652d9998f93cf3038074")
+            end
           end
 
           pending "post-vanilla-query-space" do
           end
 
           it "post-vanilla-query" do
-            request = HTTP::Request.new("POST", "/?Param1=value1", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/?Param1=value1", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=28038455d6de14eafc1f9222cf5aa6f1a96197d7deb8263271d420d138af7f11")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=28038455d6de14eafc1f9222cf5aa6f1a96197d7deb8263271d420d138af7f11")
+            end
           end
 
           it "post-vanilla" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=5da7c1a2acd57cee7505fc6676e4e544621c30862966e37dddb68e92efbe5d6b")
+            end
           end
 
           it "post-x-www-form-urlencoded-parameters" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.add("Content-Type", "application/x-www-form-urlencoded; charset=utf8")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Content-Type", "application/x-www-form-urlencoded; charset=utf8")
 
-            request.body = "Param1=value1"
+              request.body = "Param1=value1"
 
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=1a72ec8f64bd914b0e42e42607c7fbce7fb2c7465f63e3092b3b0d39fa77a6fe")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=1a72ec8f64bd914b0e42e42607c7fbce7fb2c7465f63e3092b3b0d39fa77a6fe")
+            end
           end
 
           it "post-x-www-form-urlencoded" do
-            request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("POST", "/", HTTP::Headers.new)
 
-            request.headers.add("Host", "example.amazonaws.com")
-            request.headers.add("X-Amz-Date", "20150830T123600Z")
-            request.headers.add("Content-Type", "application/x-www-form-urlencoded")
+              request.headers.add("Host", "example.amazonaws.com")
+              request.headers.add("X-Amz-Date", "20150830T123600Z")
+              request.headers.add("Content-Type", "application/x-www-form-urlencoded")
 
-            request.body = "Param1=value1"
+              request.body = "Param1=value1"
 
-            request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
+              request.headers.delete("Content-Length") # b/c HTTP::Request.new adds it
 
-            assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=ff11897932ad3f4e8b18135d722051e5ac45fc38421b1da7b9d196a0fe09473a")
+              assert_request_signed(request, "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=ff11897932ad3f4e8b18135d722051e5ac45fc38421b1da7b9d196a0fe09473a")
+            end
           end
         end
       end

--- a/spec/awscr-signer/signers/v4_spec.cr
+++ b/spec/awscr-signer/signers/v4_spec.cr
@@ -4,87 +4,85 @@ module Awscr
   module Signer
     module Signers
       describe V4 do
-        Spec.before_each do
-          Timecop.freeze(Time.local(2015, 1, 1))
-        end
-
-        Spec.after_each do
-          Timecop.reset
-        end
-
         describe "#sign" do
+          time = Time.local(2015, 1, 1)
+
           it "adds content-sha256 header by default" do
-            request = HTTP::Request.new("GET", "/", HTTP::Headers.new, "BODY")
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/", HTTP::Headers.new, "BODY")
 
-            signer = V4.new("s3", "us-east-1",
-              "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
-            signer.sign(request)
+              signer = V4.new("s3", "us-east-1",
+                "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+              signer.sign(request)
 
-            digest = OpenSSL::Digest.new("SHA256")
-            digest.update("BODY")
-            request.headers["X-Amz-Content-Sha256"].should eq(digest.hexdigest)
-            request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=791f608d3f2173e73123252f6d3eae407fedbe55d8d62d06fc45bd5ea7584fc0")
+              digest = OpenSSL::Digest.new("SHA256")
+              digest.update("BODY")
+              request.headers["X-Amz-Content-Sha256"].should eq(digest.hexdigest)
+              request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=791f608d3f2173e73123252f6d3eae407fedbe55d8d62d06fc45bd5ea7584fc0")
+            end
           end
 
           it "replaces date header with x-amz-date" do
-            time = Time.local(2015, 1, 1)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/")
+              request.headers.add("Date", Signer::Date.new(time).iso8601)
 
-            request = HTTP::Request.new("GET", "/")
-            request.headers.add("Date", Signer::Date.new(time).iso8601)
+              signer = V4.new("s3", "us-east-1",
+                "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+              signer.sign(request)
 
-            signer = V4.new("s3", "us-east-1",
-              "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
-            signer.sign(request)
-
-            request.headers.has_key?("Date").should eq(false)
-            request.headers["X-Amz-Date"].should eq(Signer::Date.new(time).iso8601)
-            request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=a0928db39f84c9d7993e5068d68d9ade9440626c9293f81cd73ae86353ccf460")
+              request.headers.has_key?("Date").should eq(false)
+              request.headers["X-Amz-Date"].should eq(Signer::Date.new(time).iso8601)
+              request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=a0928db39f84c9d7993e5068d68d9ade9440626c9293f81cd73ae86353ccf460")
+            end
           end
 
           it "does not overwrite x-amz-date with date if x-amz-date is set" do
-            time = Time.local(2015, 1, 1)
-            time2 = Time.local(2015, 2, 1)
+            with_time_freeze(time) do
+              time2 = Time.local(2015, 2, 1)
 
-            request = HTTP::Request.new("GET", "/")
-            request.headers.add("X-Amz-Date", Signer::Date.new(time2).iso8601)
-            request.headers.add("Date", Signer::Date.new(time).iso8601)
+              request = HTTP::Request.new("GET", "/")
+              request.headers.add("X-Amz-Date", Signer::Date.new(time2).iso8601)
+              request.headers.add("Date", Signer::Date.new(time).iso8601)
 
-            signer = V4.new("s3", "us-east-1",
-              "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
-            signer.sign(request)
+              signer = V4.new("s3", "us-east-1",
+                "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+              signer.sign(request)
 
-            request.headers.has_key?("Date").should eq(false)
-            request.headers["X-Amz-Date"].should eq(Signer::Date.new(time2).iso8601)
-            request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=bb6067e07d40d9dea1352f442bdd093afaceefe1a80b68990fae4f63474365ea")
+              request.headers.has_key?("Date").should eq(false)
+              request.headers["X-Amz-Date"].should eq(Signer::Date.new(time2).iso8601)
+              request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=bb6067e07d40d9dea1352f442bdd093afaceefe1a80b68990fae4f63474365ea")
+            end
           end
 
           it "sets x-amz-date if not set and no date given" do
-            time = Time.local(2015, 1, 1)
+            with_time_freeze(time) do
+              request = HTTP::Request.new("GET", "/")
 
-            request = HTTP::Request.new("GET", "/")
+              signer = V4.new("s3", "us-east-1",
+                "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+              signer.sign(request)
 
-            signer = V4.new("s3", "us-east-1",
-              "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
-            signer.sign(request)
-
-            request.headers.has_key?("Date").should eq(false)
-            request.headers["X-Amz-Date"].should eq(Signer::Date.new(time).iso8601)
-            request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=a0928db39f84c9d7993e5068d68d9ade9440626c9293f81cd73ae86353ccf460")
+              request.headers.has_key?("Date").should eq(false)
+              request.headers["X-Amz-Date"].should eq(Signer::Date.new(time).iso8601)
+              request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=a0928db39f84c9d7993e5068d68d9ade9440626c9293f81cd73ae86353ccf460")
+            end
           end
 
           it "does not overwrite x-amx-date if no date is given and it is set" do
-            time = Time.local(2015, 2, 1)
+            with_time_freeze(time) do
+              time2 = Time.local(2015, 2, 1)
+              request = HTTP::Request.new("GET", "/")
+              request.headers.add("X-Amz-Date", Signer::Date.new(time2).iso8601)
 
-            request = HTTP::Request.new("GET", "/")
-            request.headers.add("X-Amz-Date", Signer::Date.new(time).iso8601)
+              signer = V4.new("s3", "us-east-1",
+                "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+              signer.sign(request)
 
-            signer = V4.new("s3", "us-east-1",
-              "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
-            signer.sign(request)
-
-            request.headers.has_key?("Date").should eq(false)
-            request.headers["X-Amz-Date"].should eq(Signer::Date.new(time).iso8601)
-            request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=bb6067e07d40d9dea1352f442bdd093afaceefe1a80b68990fae4f63474365ea")
+              request.headers.has_key?("Date").should eq(false)
+              request.headers["X-Amz-Date"].should eq(Signer::Date.new(time2).iso8601)
+              request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=bb6067e07d40d9dea1352f442bdd093afaceefe1a80b68990fae4f63474365ea")
+            end
           end
         end
       end

--- a/spec/awscr-signer/signers/v4_spec.cr
+++ b/spec/awscr-signer/signers/v4_spec.cr
@@ -5,7 +5,7 @@ module Awscr
     module Signers
       describe V4 do
         Spec.before_each do
-          Timecop.freeze(Time.new(2015, 1, 1))
+          Timecop.freeze(Time.local(2015, 1, 1))
         end
 
         Spec.after_each do
@@ -27,7 +27,7 @@ module Awscr
           end
 
           it "replaces date header with x-amz-date" do
-            time = Time.new(2015, 1, 1)
+            time = Time.local(2015, 1, 1)
 
             request = HTTP::Request.new("GET", "/")
             request.headers.add("Date", Signer::Date.new(time).iso8601)
@@ -42,8 +42,8 @@ module Awscr
           end
 
           it "does not overwrite x-amz-date with date if x-amz-date is set" do
-            time = Time.new(2015, 1, 1)
-            time2 = Time.new(2015, 2, 1)
+            time = Time.local(2015, 1, 1)
+            time2 = Time.local(2015, 2, 1)
 
             request = HTTP::Request.new("GET", "/")
             request.headers.add("X-Amz-Date", Signer::Date.new(time2).iso8601)
@@ -59,7 +59,7 @@ module Awscr
           end
 
           it "sets x-amz-date if not set and no date given" do
-            time = Time.new(2015, 1, 1)
+            time = Time.local(2015, 1, 1)
 
             request = HTTP::Request.new("GET", "/")
 
@@ -73,7 +73,7 @@ module Awscr
           end
 
           it "does not overwrite x-amx-date if no date is given and it is set" do
-            time = Time.new(2015, 2, 1)
+            time = Time.local(2015, 2, 1)
 
             request = HTTP::Request.new("GET", "/")
             request.headers.add("X-Amz-Date", Signer::Date.new(time).iso8601)

--- a/spec/awscr-signer/v2/signature_spec.cr
+++ b/spec/awscr-signer/v2/signature_spec.cr
@@ -4,7 +4,7 @@ module Awscr
   module Signer::V2
     describe Signature do
       it "returns reasonable sig" do
-        time = Time.new(2007, 3, 27, 19, 36, 42)
+        time = Time.local(2007, 3, 27, 19, 36, 42)
         date = Signer::Date.new(time)
         scope = Signer::Scope.new("us-east-1", "s3", time)
         creds = Signer::Credentials.new("AKIAIOSFODNN7EXAMPLE",
@@ -35,7 +35,7 @@ Tue, 27 Mar 2007 19:36:42 +0000
         request.headers.add("Content-Encoding", "gzip")
         request.headers.add("Content-Length", "5913339")
 
-        time = Time.new(2007, 3, 27, 21, 6, 8)
+        time = Time.local(2007, 3, 27, 21, 6, 8)
         date = Signer::Date.new(time)
         scope = Signer::Scope.new("us-east-1", "s3", time)
         creds = Signer::Credentials.new("AKIAIOSFODNN7EXAMPLE",

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,9 +2,10 @@ require "spec"
 require "../src/awscr-signer"
 require "timecop"
 
-# Monkey patch Time\Timecop
-struct Time
-  def self.utc_now
-    Timecop.now
+Timecop.safe_mode = true
+
+def self.with_time_freeze(time, &block)
+  Timecop.freeze(time) do
+    block.call
   end
 end

--- a/src/awscr-signer/core/query_string.cr
+++ b/src/awscr-signer/core/query_string.cr
@@ -31,7 +31,7 @@ module Awscr
 
       # :nodoc:
       private def encoded_kv(k, v)
-        "#{URI.encode(k)}=#{URI.encode(v)}"
+        "#{URI.encode_www_form(k, space_to_plus: false)}=#{URI.encode_www_form(v, space_to_plus: false)}"
       end
     end
   end

--- a/src/awscr-signer/core/query_string.cr
+++ b/src/awscr-signer/core/query_string.cr
@@ -31,7 +31,7 @@ module Awscr
 
       # :nodoc:
       private def encoded_kv(k, v)
-        "#{URI.escape(k)}=#{URI.escape(v)}"
+        "#{URI.encode(k)}=#{URI.encode(v)}"
       end
     end
   end


### PR DESCRIPTION
I appear to still be getting;

```
In /usr/local/Cellar/crystal/0.31.0/src/uri/encoding.cr:174:3

 174 | def self.escape(string : String, space_to_plus = false)
       ^-----
Warning: Deprecated URI.escape. Use .encode or .encode_www_form instead
```

Which I tracked down to be from the changed file in this PR. I believe encode is the right method here, as per crystal-lang/crystal#7997.

> Adds methods URI.encode and URI.decode for URL encoding without escaping reserved characters. These are to be used **when encoding URLs.**