### PR TITLE
The URI interface have changed.

### DIFF
--- a/src/awscr-signer/core/query_string.cr
+++ b/src/awscr-signer/core/query_string.cr
@@ -31,7 +31,7 @@ module Awscr
 
       # :nodoc:
       private def encoded_kv(k, v)
-        "#{URI.encode_www_form(k, space_to_plus: false)}=#{URI.encode_www_form(v, space_to_plus: false)}"
+        "#{URI.escape(k, space_to_plus: false)}=#{URI.encode_www_form(v, space_to_plus: false)}"
       end
     end
   end

--- a/src/awscr-signer/core/query_string.cr
+++ b/src/awscr-signer/core/query_string.cr
@@ -31,7 +31,7 @@ module Awscr
 
       # :nodoc:
       private def encoded_kv(k, v)
-        "#{URI.escape(k, space_to_plus: false)}=#{URI.encode_www_form(v, space_to_plus: false)}"
+        "#{URI.escape(k, space_to_plus: false)}=#{URI.escape(v, space_to_plus: false)}"
       end
     end
   end

--- a/src/awscr-signer/v4/uri.cr
+++ b/src/awscr-signer/v4/uri.cr
@@ -14,7 +14,7 @@ module Awscr
       @query = QueryString.new
 
       def self.encode(path : String)
-        URI.encode(path)
+        URI.escape(path)
       end
 
       # The path must be non encoded.


### PR DESCRIPTION
We should now use the escape method.
https://crystal-lang.org/api/0.20.1/URI.html