### PR TITLE
fixed deprecation warning 'use final.hexstring instead'

### DIFF
--- a/spec/awscr-signer/signers/v4_spec.cr
+++ b/spec/awscr-signer/signers/v4_spec.cr
@@ -17,7 +17,7 @@ module Awscr
 
               digest = OpenSSL::Digest.new("SHA256")
               digest.update("BODY")
-              request.headers["X-Amz-Content-Sha256"].should eq(digest.hexdigest)
+              request.headers["X-Amz-Content-Sha256"].should eq(digest.final.hexstring)
               request.headers["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150101/us-east-1/s3/aws4_request, SignedHeaders=x-amz-content-sha256;x-amz-date, Signature=791f608d3f2173e73123252f6d3eae407fedbe55d8d62d06fc45bd5ea7584fc0")
             end
           end

--- a/src/awscr-signer/v4/request.cr
+++ b/src/awscr-signer/v4/request.cr
@@ -72,7 +72,7 @@ module Awscr
           end
           body.rewind
 
-          digest.hexdigest
+          digest.final.hexstring
         end
       end
 

--- a/src/awscr-signer/v4/signature.cr
+++ b/src/awscr-signer/v4/signature.cr
@@ -52,7 +52,7 @@ module Awscr
       private def digest
         digest = OpenSSL::Digest.new("SHA256")
         digest.update(@string)
-        digest.hexdigest
+        digest.final.hexstring
       end
 
       # :nodoc:


### PR DESCRIPTION
I was using another library "awscr-s3" and created a simple app to list_buckets in s3:

```
require "dotenv"
require "awscr-s3"

Dotenv.load ".env"

AWS_KEY = ENV["AWS_KEY"]
AWS_SECRET = ENV["AWS_SECRET"]


client = Awscr::S3::Client.new("us-east-1", AWS_KEY, AWS_SECRET)
resp = client.list_buckets
p resp.buckets.map(&.name) 
```

I was getting a warning message below: 
```
In /usr/share/crystal/src/digest/base.cr:143:5

 143 | digest.hexstring
       ^-----
Warning: Deprecated OpenSSL::Digest#digest. Use `final` instead.
```

I tracked it down to here and changed the digest.hexdigest to digest.final.hexstring and was able to stop the warning message.

