### PR TITLE
Crystal 1.0.0 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: awscr-signer
 version: 0.8.1
-crystal: 0.31.0
+crystal: ">=0.31.0"
 
 authors:
   - Taylor Finnell <tmfinnell@gmail.com>


### PR DESCRIPTION
Will otherwise raise: 
```
- `crystal (< 1.0.0)` required by `awscr-signer 0.2.1`
```