### PR TITLE
Enable tests against Crystal nightly build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
           - 1.14.1
           - 1.15.1
         experimental: [false]
+        include:
+          - crystal_version: nightly
+            experimental: true
     name: Crystal ${{ matrix.crystal_version }}
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/spec/awscr-signer/v4/signature_spec.cr
+++ b/spec/awscr-signer/v4/signature_spec.cr
@@ -40,6 +40,30 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
         sig.to_s.should eq("08c7e5a9acfcfeb3ab6b2185e75ce8b1deb5e634ec47601a50643f830c755c01")
       end
+
+      it "test the wrong generated canonical_request without path" do
+        time = Time.unix(1440938160)
+        key = "AKIDEXAMPLE"
+        secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        region = "us-east-1"
+        service = "service"
+
+        canonical_request = <<-TEXT
+        GET
+
+
+        host:example.amazonaws.com
+        x-amz-date:20150830T123600Z
+
+        host;x-amz-date
+        e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        TEXT
+
+        scope = Scope.new(region, service, time)
+        sig = Signature.new(scope, canonical_request, Credentials.new(key, secret))
+
+        sig.to_s.should eq("a2e75998cb7d53a2e958eb45335825f43aa137f7ed6ba30ec16fe18c0f294c97")
+      end
     end
   end
 end

--- a/src/awscr-signer/signers/v4.cr
+++ b/src/awscr-signer/signers/v4.cr
@@ -73,8 +73,12 @@ module Awscr
             request.headers["X-Amz-Date"] ||= scope.date.iso8601
           end
 
-          canonical_request = Signer::V4::Request.new(request.method,
-            request.path, request.body, encode_path)
+          canonical_request = Signer::V4::Request.new(
+            request.method,
+            request.path,
+            request.body,
+            encode_path
+          )
 
           request.query_params.to_h.each do |k, v|
             canonical_request.query.add(k, v)

--- a/src/awscr-signer/v4/request.cr
+++ b/src/awscr-signer/v4/request.cr
@@ -99,6 +99,8 @@ module Awscr
                             ignored. Use #query object intead") unless uri.query.nil?
 
         path = uri.normalize.path
+        return "/" if path.blank?
+
         if @encode
           self.class.encode_path(path)
         else


### PR DESCRIPTION
The current implementation of `HTTP::Request` has changed slightly with [crystal-lang/crystal#15499](https://github.com/crystal-lang/crystal/pull/15499),
now returning `//` for `HTTP::Request.new("GET", "//", HTTP::Headers.new)`.  

This behavior treats the request resource as a URL, even though it could be just a path.
Checking the path after normalization should cover this case.