### PR TITLE
Fix Crystal 1.19.1 compatibility

### DIFF
--- a/src/awscr-signer/core/header.cr
+++ b/src/awscr-signer/core/header.cr
@@ -10,8 +10,7 @@ module Awscr
     # header.to_s # => k:v,value2
     # ```
     class Header
-      include Comparable(Header)
-      include Comparable(String)
+      include Comparable(Header | String)
 
       @values = [] of String
 
@@ -51,12 +50,12 @@ module Awscr
         io << "#{key}:#{value}"
       end
 
-      def <=>(other : Header) : Int
-        other.key <=> key
-      end
-
-      def <=>(other : String) : Int
-        Header.new(other, "") <=> self
+      def <=>(other : Header | String) : Int32
+        case other
+        when Header then other.key <=> key
+        when String then Header.new(other, "") <=> self
+        else 0
+        end
       end
     end
   end

--- a/src/awscr-signer/core/header_collection.cr
+++ b/src/awscr-signer/core/header_collection.cr
@@ -11,6 +11,7 @@ module Awscr
     # ```
     class HeaderCollection
       include Enumerable(Header)
+      include Indexable(Header)
 
       # List of headers names not allowed in the collection.
       BLACKLIST_HEADERS = [
@@ -87,6 +88,14 @@ module Awscr
       # Yields each header
       def each(&)
         @headers.each { |header| yield header }
+      end
+
+      def size : Int32
+        @headers.size
+      end
+
+      def unsafe_fetch(index : Int) : Header
+        @headers.unsafe_fetch(index)
       end
 
       # Returns the collection of headers separated by newline with a trailing

--- a/src/awscr-signer/core/header_key.cr
+++ b/src/awscr-signer/core/header_key.cr
@@ -21,7 +21,7 @@ module Awscr
       end
 
       # Compare to another key
-      def <=>(other : HeaderKey) : Int
+      def <=>(other : HeaderKey) : Int32
         to_s <=> other.to_s
       end
     end


### PR DESCRIPTION
Hi !
Claude identified those necessary fixes for Crystal 1.19.1 , feel free to merge them if they look good to you - thanks!

```
Fixes compilation errors on Crystal 1.19.1 (tested on 1.19.1).

**header_collection.cr:** Add `Indexable(Header)` with required `size` and `unsafe_fetch` methods.

**header.cr:** Merge dual `Comparable` includes into `Comparable(Header | String)` union, consolidate `<=>` overloads, fix `Int` → `Int32` return type.

**header_key.cr:** Fix `<=>` return type `Int` → `Int32`.
```

These fixes were identified and implemented with the assistance of Claude (Anthropic's AI assistant, claude.ai).